### PR TITLE
Miniboss fix

### DIFF
--- a/src/commands/miniboss/miniboss.command.ts
+++ b/src/commands/miniboss/miniboss.command.ts
@@ -94,9 +94,9 @@ export class MinibossCommand implements CommandClass {
     const $ = load(<string>html);
 
     // Load the body text and remove that one stupid post that messes everything up
-let bodyText = c('body')
-  .text()
-  .replace('Reading text with a timer is a bit stressful, so I added still frames of this tutorial:', '');
+    let bodyText = $('body')
+      .text()
+      .replace('Reading text with a timer is a bit stressful, so I added still frames of this tutorial:', '');
 
     // Get all gifs
     let gifs = $('img').filter((i, img) => !!~img.attribs['src'].indexOf('gif'));
@@ -110,12 +110,12 @@ let bodyText = c('body')
     // Combine all the data
     let minibossData: MinibossPost[] = [];
 
-imageSourceList.forEach((source, index) => {
-  minibossData.push({
-    title: titles[index],
-    image: source
-  });
-});
+    imageSourceList.forEach((source, index) => {
+      minibossData.push({
+        title: titles[index],
+        image: source
+      });
+    });
 
     return minibossData.reverse();
   }

--- a/src/commands/miniboss/miniboss.command.ts
+++ b/src/commands/miniboss/miniboss.command.ts
@@ -94,30 +94,30 @@ export class MinibossCommand implements CommandClass {
     const $ = load(<string>html);
 
     // Load the body text and remove that one stupid post that messes everything up
-    let bodyText = $('body')
-      .text()
-      .replace('Reading text with a timer is a bit stressful, so I added still frames of this tutorial:', '');
+let bodyText = c('body')
+  .text()
+  .replace('Reading text with a timer is a bit stressful, so I added still frames of this tutorial:', '');
 
     // Get all gifs
     let gifs = $('img').filter((i, img) => !!~img.attribs['src'].indexOf('gif'));
 
     // Get all post titles
-    let titles = bodyText.match(/#[0-9]+( | )([^#])+/g);
+    let titles = bodyText.match(/#[0-9]+( | )([^#\n])+/g).reverse();
 
     // Retrieve the source links for each image
-    let imageSourceList = gifs.toArray().map(img => img.attribs['src']);
+    let imageSourceList = gifs.toArray().map(img => img.attribs['src']).reverse();
 
     // Combine all the data
     let minibossData: MinibossPost[] = [];
 
-    imageSourceList.forEach((source, index) => {
-      minibossData.push({
-        title: titles[index],
-        image: source
-      });
-    });
+imageSourceList.forEach((source, index) => {
+  minibossData.push({
+    title: titles[index],
+    image: source
+  });
+});
 
-    return minibossData;
+    return minibossData.reverse();
   }
 
   /**

--- a/src/commands/miniboss/miniboss.command.ts
+++ b/src/commands/miniboss/miniboss.command.ts
@@ -67,8 +67,8 @@ export class MinibossCommand implements CommandClass {
   async getPostByNumber(postNumber: number) {
     let postData = await this.getMinibossPostData();
     if (!postData) return false;
-
-    return postData.filter(post => !!~post.title.indexOf(postNumber.toString()));
+    
+    return postData.filter(post => !!(post.num == postNumber));
   }
 
   /**
@@ -109,15 +109,18 @@ export class MinibossCommand implements CommandClass {
 
     // Combine all the data
     let minibossData: MinibossPost[] = [];
-
+    
     imageSourceList.forEach((source, index) => {
+      let regex = /#([0-9]+).*/g;
+      let num = regex.exec(titles[index])[1];
       minibossData.push({
         title: titles[index],
-        image: source
+        image: source,
+        num: Number(num)
       });
     });
 
-    return minibossData.reverse();
+    return minibossData;
   }
 
   /**
@@ -142,4 +145,8 @@ interface MinibossPost {
 
   /** Image URL */
   image: string;
+  
+  /** Post title number */
+  num: number;
 }
+

--- a/src/commands/miniboss/miniboss.command.ts
+++ b/src/commands/miniboss/miniboss.command.ts
@@ -67,8 +67,8 @@ export class MinibossCommand implements CommandClass {
   async getPostByNumber(postNumber: number) {
     let postData = await this.getMinibossPostData();
     if (!postData) return false;
-    
-    return postData.filter(post => !!(post.num == postNumber));
+
+    return postData.filter(post => !!(post.num === postNumber));
   }
 
   /**
@@ -109,7 +109,7 @@ export class MinibossCommand implements CommandClass {
 
     // Combine all the data
     let minibossData: MinibossPost[] = [];
-    
+
     imageSourceList.forEach((source, index) => {
       let regex = /#([0-9]+).*/g;
       let num = regex.exec(titles[index])[1];
@@ -145,8 +145,7 @@ interface MinibossPost {
 
   /** Image URL */
   image: string;
-  
+
   /** Post title number */
   num: number;
 }
-


### PR DESCRIPTION
Fixes miniboss command.

Looks like miniboss added a couple of articles to the top of the page, which caused the titles and the gifs to go out of sync.  The quick solution was to reverse the lists so the gifs and titles are matched up from the bottom.

However, this breaks the numerical search which previously used strpos (i.e. searching for "5" would return "65" first).  This has now been resolved by parsing out the actual post number and searching by that instead.