### PR TITLE
Allow tagging others with doc reply

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "express": "^4.16.3",
     "gifsicle": "^3.0.4",
     "glob": "^7.1.2",
-    "jimp": "^0.2.28",
+    "jimp": "^0.3.5",
     "js-beautify": "^1.7.5",
     "jsonwebtoken": "^8.2.1",
     "nedb": "^1.8.0",

--- a/src/commands/docs/docs.command.ts
+++ b/src/commands/docs/docs.command.ts
@@ -51,9 +51,7 @@ export class DocsCommand implements CommandClass {
       if (args.indexOf('-i') !== -1) image = true;
 
       // find a tag
-      whoTag = args.find(arg => {
-        return arg.match(/^<@\d+>$/) !== null;
-      });
+      whoTag = msg.mentions.members.first()
     }
 
     // clean up tag
@@ -63,7 +61,7 @@ export class DocsCommand implements CommandClass {
       // Determine if author is staff
       let role = detectStaff(msg.member);
       if (role) {
-        whoTag = whoTag.replace(/[<!@>]+/g, '');
+        whoTag = whoTag.id;
       } else {
         whoTag = msg.author.id;
       }

--- a/src/commands/docs/docs.command.ts
+++ b/src/commands/docs/docs.command.ts
@@ -40,7 +40,7 @@ export class DocsCommand implements CommandClass {
     // Default to GMS2 documentation
     let version = 'GMS2';
     let image = false;
-    let who_tag = undefined;
+    let whoTag;
 
     if (args.length === 1) {
       // Throw on unsupplied function
@@ -51,27 +51,27 @@ export class DocsCommand implements CommandClass {
       if (args.indexOf('-i') !== -1) image = true;
 
       // find a tag
-      who_tag = args.find(function(arg) {
-        return arg.match(/^<@\d+>$/) !== null
+      whoTag = args.find(arg => {
+        return arg.match(/^<@\d+>$/) !== null;
       });
     }
 
     // clean up tag
-    if (who_tag === undefined) {
-      who_tag = msg.author.id;
+    if (whoTag === undefined) {
+      whoTag = msg.author.id;
     } else {
       // Determine if author is staff
       let role = detectStaff(msg.member);
       if (role) {
-        who_tag = who_tag.replace(/[<!@>]+/g, '');
+        whoTag = whoTag.replace(/[<!@>]+/g, '');
       } else {
-        who_tag = msg.author.id;
+        whoTag = msg.author.id;
       }
     }
 
-    msg.guild.fetchMember(who_tag).then(member => {
+    msg.guild.fetchMember(whoTag).then(member => {
       if (!member) {
-        msg.author.send(`<@${who_tag}> was not a recognized user.`);
+        msg.author.send(`<@${whoTag}> was not a recognized user.`);
       } else {
         // Switch on version
         switch (version) {

--- a/src/commands/docs/docs.command.ts
+++ b/src/commands/docs/docs.command.ts
@@ -50,8 +50,8 @@ export class DocsCommand implements CommandClass {
       version = ~args.indexOf('gms1') || ~args.indexOf('GMS1') ? 'GMS1' : 'GMS2';
       if (args.indexOf('-i') !== -1) image = true;
 
-      // find a tag
-      whoTag = msg.mentions.members.first()
+      // find a mention tag
+      whoTag = msg.mentions.members.first();
     }
 
     // clean up tag

--- a/src/commands/docs/docs.command.ts
+++ b/src/commands/docs/docs.command.ts
@@ -52,7 +52,7 @@ export class DocsCommand implements CommandClass {
 
       // find a tag
       who_tag = args.find(function(arg) {
-        return args.match(/^<@\d+>$/) !== null
+        return arg.match(/^<@\d+>$/) !== null
       });
     }
 
@@ -61,7 +61,7 @@ export class DocsCommand implements CommandClass {
       who_tag = msg.author.id;
     } else {
       // Determine if author is staff
-      let role = detectStaff(msg.author);
+      let role = detectStaff(msg.member);
       if (role) {
         who_tag = who_tag.replace(/[<!@>]+/g, '');
       } else {
@@ -112,7 +112,7 @@ export class DocsCommand implements CommandClass {
    * @param image whether to include a screenshot
    * @param who who to tag about the message
    */
-  helpUrlGMS1(msg: Message, fn: string, image, who: string) {
+  helpUrlGMS1(msg: Message, fn: string, image, who) {
     let found = false;
 
     // Loop through valid titles
@@ -153,7 +153,7 @@ export class DocsCommand implements CommandClass {
    * @param image whether to include a screenshot
    * @param who who to tag about the message
    */
-  helpUrlGMS2(msg: Message, fn: string, image, who: string) {
+  helpUrlGMS2(msg: Message, fn: string, image, who) {
     // Download super saucy secret file from YYG server
     http.get('http://docs2.yoyogames.com/files/searchdat.js', res => {
       // Read like a normal bot


### PR DESCRIPTION
Adds the ability to tag someone else with a !doc command.  Detects an @ mention in any argument position (e.g. `!doc instance_place @meseta`.  Only staff/duckies can use the tag argument, as checked by `detectStaff`; any regular users attempting to use it, the argument will simply be ignored, and the original poster will be tagged instead.