### PR TITLE
Fixes docs dm

### DIFF
--- a/src/commands/docs/docs.command.ts
+++ b/src/commands/docs/docs.command.ts
@@ -144,7 +144,7 @@ export class DocsCommand implements CommandClass {
    * @param msg The Discord message asking for help
    * @param fn Function name to lookup
    * @param image whether to include a screenshot
-   * @param whoTag who to tag about the message
+   * @param who who to tag about the message
    */
   helpUrlGMS2(msg: Message, fn: string, image, who) {
     // Download super saucy secret file from YYG server

--- a/src/commands/docs/docs.command.ts
+++ b/src/commands/docs/docs.command.ts
@@ -51,55 +51,53 @@ export class DocsCommand implements CommandClass {
       if (args.indexOf('-i') !== -1) image = true;
 
       // find a mention tag
-      whoTag = msg.mentions.members.first();
+      let taggedMember = msg.mentions.members;
+      let taggedUser = msg.mentions.users;
+      
+      if (msg.mentions.users !== null && detectStaff(msg.member)) {
+          
+        // check if tagged user is a member of of the server
+        if (msg.mentions.members === null || msg.mentions.users.first().id != msg.mentions.members.first().id) {
+          msg.author.send(`<@${whoTag}> was not a recognized user.`);
+          return;
+        }
+        
+        whoTag = msg.mentions.users.first().id;
+      }
     }
 
     // clean up tag
     if (whoTag === undefined) {
       whoTag = msg.author.id;
-    } else {
-      // Determine if author is staff
-      let role = detectStaff(msg.member);
-      if (role) {
-        whoTag = whoTag.id;
-      } else {
-        whoTag = msg.author.id;
-      }
     }
 
-    msg.guild.fetchMember(whoTag).then(member => {
-      if (!member) {
-        msg.author.send(`<@${whoTag}> was not a recognized user.`);
-      } else {
-        // Switch on version
-        switch (version) {
-          case 'GMS1':
-            // Determine if the provided function is a valid GMS1 function
-            if (validateGMS1(args[1])) {
-              // If so, provide the helps
-              this.helpUrlGMS1(msg, args[1], image, member);
-            } else {
-              // Otherwise, provide the nopes
-              msg.author.send(`\`${args[1]}\` was not a recognized GMS1 function. Type \`!help\` for help with commands.`);
-            }
-            break;
-          case 'GMS2':
-            // Determine if the provided function is a valid GMS2 function
-            if (validateGMS2(args[1])) {
-              // If so, give 'em the goods
-              this.helpUrlGMS2(msg, args[1], image, member);
-            } else {
-              // Otherwise, kick 'em to the curb
-              msg.author.send(`\`${args[1]}\` was not a recognized GMS2 function. Type \`!help\` for help with commands.`);
-            }
-            break;
-          default:
-            // Invalid GMS version (this is actually impossible to reach, here just in case functionality changes)
-            msg.author.send(`\`${version}\` was not a valid option. Type \`!help\` for help with commands.`);
-            break;
+    // Switch on version
+    switch (version) {
+      case 'GMS1':
+        // Determine if the provided function is a valid GMS1 function
+        if (validateGMS1(args[1])) {
+          // If so, provide the helps
+          this.helpUrlGMS1(msg, args[1], image, whoTag);
+        } else {
+          // Otherwise, provide the nopes
+          msg.author.send(`\`${args[1]}\` was not a recognized GMS1 function. Type \`!help\` for help with commands.`);
         }
-      }
-    });
+        break;
+      case 'GMS2':
+        // Determine if the provided function is a valid GMS2 function
+        if (validateGMS2(args[1])) {
+          // If so, give 'em the goods
+          this.helpUrlGMS2(msg, args[1], image, whoTag);
+        } else {
+          // Otherwise, kick 'em to the curb
+          msg.author.send(`\`${args[1]}\` was not a recognized GMS2 function. Type \`!help\` for help with commands.`);
+        }
+        break;
+      default:
+        // Invalid GMS version (this is actually impossible to reach, here just in case functionality changes)
+        msg.author.send(`\`${version}\` was not a valid option. Type \`!help\` for help with commands.`);
+        break;
+    }
 
   }
 
@@ -128,7 +126,7 @@ export class DocsCommand implements CommandClass {
         }
 
         // Put together a URL and serve it on a silver platter
-        msg.channel.send(`Here's the GMS1 documentation for \`${fn}\`, ${who}`);
+        msg.channel.send(`Here's the GMS1 documentation for \`${fn}\`, <@${who}>`);
         msg.channel.send(encodeURI(`http://docs.yoyogames.com/${this.gms1DocumentationUrls.files[i]}`));
 
         // We struck gold, ma!
@@ -149,7 +147,7 @@ export class DocsCommand implements CommandClass {
    * @param msg The Discord message asking for help
    * @param fn Function name to lookup
    * @param image whether to include a screenshot
-   * @param who who to tag about the message
+   * @param whoTag who to tag about the message
    */
   helpUrlGMS2(msg: Message, fn: string, image, who) {
     // Download super saucy secret file from YYG server
@@ -185,7 +183,7 @@ export class DocsCommand implements CommandClass {
             }
 
             // Provide it
-            msg.channel.send(`Here's the GMS2 documentation for \`${fn}\`, ${who}`);
+            msg.channel.send(`Here's the GMS2 documentation for \`${fn}\`, <@${who}>`);
             msg.channel.send(encodeURI(`http://docs2.yoyogames.com/${SearchFiles[i]}`));
 
             // Indiciate we found it
@@ -249,3 +247,4 @@ export class DocsCommand implements CommandClass {
     });
   }
 }
+

--- a/src/commands/docs/docs.command.ts
+++ b/src/commands/docs/docs.command.ts
@@ -53,15 +53,15 @@ export class DocsCommand implements CommandClass {
       // find a mention tag
       let taggedMember = msg.mentions.members;
       let taggedUser = msg.mentions.users;
-      
+
       if (msg.mentions.users !== null && detectStaff(msg.member)) {
-          
+
         // check if tagged user is a member of of the server
-        if (msg.mentions.members === null || msg.mentions.users.first().id != msg.mentions.members.first().id) {
+        if (msg.mentions.members === null || msg.mentions.users.first().id !== msg.mentions.members.first().id) {
           msg.author.send(`<@${whoTag}> was not a recognized user.`);
           return;
         }
-        
+
         whoTag = msg.mentions.users.first().id;
       }
     }
@@ -247,4 +247,3 @@ export class DocsCommand implements CommandClass {
     });
   }
 }
-

--- a/src/commands/docs/docs.command.ts
+++ b/src/commands/docs/docs.command.ts
@@ -51,9 +51,6 @@ export class DocsCommand implements CommandClass {
       if (args.indexOf('-i') !== -1) image = true;
 
       // find a mention tag
-      let taggedMember = msg.mentions.members;
-      let taggedUser = msg.mentions.users;
-
       if (msg.mentions.users !== null && detectStaff(msg.member)) {
 
         // check if tagged user is a member of of the server
@@ -66,7 +63,7 @@ export class DocsCommand implements CommandClass {
       }
     }
 
-    // clean up tag
+    // tag self if no tag provided
     if (whoTag === undefined) {
       whoTag = msg.author.id;
     }


### PR DESCRIPTION
`msg.guild.fetchMembers()` was previously used to check for valid member tags.  However, this errors on DMs as `guild` property does not exist.  It also incurs an additional API action.

This PR re-implements valid member tag checking using a comparison between `msg.mentions.users` and `msg.mentions.members`.  This allows valid member checking without incurring a fetchMembers() API call, as well as remaining valid in DMs.