### PR TITLE
Changed default security state to true at lazyeye's request.

### DIFF
--- a/src/shared/services/security.service.ts
+++ b/src/shared/services/security.service.ts
@@ -7,7 +7,8 @@ class SecurityService {
   private currentSecurityState: boolean;
 
   constructor() {
-    this.currentSecurityState = false;
+    /** Default security state set to true. */
+    this.currentSecurityState = true;
   }
 
   /**


### PR DESCRIPTION
@imlazyeye requested that the security state default to `true` in the case of bot crashes. 