### PR TITLE
Adding !cgh and removing unusable rule

### DIFF
--- a/src/commands/github/github.command.ts
+++ b/src/commands/github/github.command.ts
@@ -4,7 +4,7 @@ import { Command, CommandClass } from '../../shared';
 import * as https from 'https';
 
 @Command({
-  matches: ['github', 'community-github', 'gh'],
+  matches: ['github', 'community-github', 'gh', 'cgh'],
   ...prefixedCommandRuleTemplate
 })
 export class GithubCommand implements CommandClass {

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -197,10 +197,6 @@ export function loadRules() {
       ['👋']
     ),
     RuleFactory.createReactionRule(
-      ['<@361088614735544320>', '<@!361088614735544320>'],
-      ['🇸', '🇦', '🇷', '🅰']
-    ),
-    RuleFactory.createReactionRule(
       ['hmm'],
       ['🇭', '🇲', 'Ⓜ'],
       true


### PR DESCRIPTION
Now that my old account is gone, the gmbot reactions from when I'm pinged are useless as well! So that's gone. I also allowed `!cgh` to trigger the GitHub command, as requested by sanbox.