### PR TITLE
Sara's a Dingus and didn't properly test

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -12,6 +12,9 @@ export const prefixedCommandRuleTemplate = {
   delete: true
 };
 
+/** Default channel description for the help channels */
+export const helpChannelDesc = ':pray: Need a hand with GameMaker?';
+
 /** How long to wait before considering a help channel no longer busy, in milliseconds */
 export const helpChannelBusyTimeout = 1000 * 60 * 10;
 

--- a/src/shared/services/help-channel.service.ts
+++ b/src/shared/services/help-channel.service.ts
@@ -1,4 +1,4 @@
-import { helpChannelBusyTimeout, serverIDs } from '../../config';
+import { helpChannelBusyTimeout, serverIDs, helpChannelDesc } from '../../config';
 import { channelService } from '../';
 import { GuildChannel, TextChannel, Message } from 'discord.js';
 import { detectStaff } from '../utils/detect-staff';
@@ -59,7 +59,7 @@ class HelpChannelService {
         currentName.replace(this.regex, '')
       )
       .then(() => {
-        helpChannelController.channel.setTopic(`:pray: Need a hand with GameMaker?`);
+        helpChannelController.channel.setTopic(helpChannelDesc);
       });
 
       clearTimeout(helpChannelController.timer);
@@ -108,7 +108,7 @@ class HelpChannelService {
       controller.channel
         .setName(currentName.replace(this.regex, ''))
         .then(() => {
-          controller.channel.setTopic(':pray: Need a hand with GameMaker?');
+          controller.channel.setTopic(helpChannelDesc);
         });
       controller.busy = false;
     }, helpChannelBusyTimeout);

--- a/src/shared/services/help-channel.service.ts
+++ b/src/shared/services/help-channel.service.ts
@@ -105,7 +105,11 @@ class HelpChannelService {
     const currentName = controller.channel.name;
 
     controller.timer = setTimeout(() => {
-      controller.channel.setName(currentName.replace(this.regex, ''));
+      controller.channel
+        .setName(currentName.replace(this.regex, ''))
+        .then(() => {
+          controller.channel.setTopic(':pray: Need a hand with GameMaker?');
+        });
       controller.busy = false;
     }, helpChannelBusyTimeout);
   }


### PR DESCRIPTION
I noticed tonight that I never included a reset of the channel description in the help channel timeout, only in the `!done` command. That was fixed in this PR. 

I also decided to put the default channel description in config, just so it has the ability to be easily modified, in a uniform manner, since it's referenced more than once.