### PR TITLE
Added extra security to "commencejingle" command

### DIFF
--- a/src/commands/christmas/christmas.command.ts
+++ b/src/commands/christmas/christmas.command.ts
@@ -46,7 +46,7 @@ export class ChristmasCommand implements CommandClass {
         this.cycle();
         break;
       case 'commencejingle':
-        if (msg.member.user.username.includes('topher')) {
+        if (msg.author.id === '144913457429348352') {
           this.setupRoles(msg);
         }
         break;


### PR DESCRIPTION
The previous method of checking for the substring "topher" within the user's name could lead to potential security issues, as users named "christopher" or "topher1205" could call this command. This PR checks directly for topherlicious's unique user ID instead of the substring, making it much more secure.