### PR TITLE
Clean up starter command, add 2 resources

### DIFF
--- a/src/commands/starter/resources.ts
+++ b/src/commands/starter/resources.ts
@@ -9,7 +9,7 @@ export const resources: ResourceList = {
     },
     {
       title: 'GMS2 Documentation',
-      url: 'http://docs2.yoyogames.com/'
+      url: 'http://manual.yoyogames.com/'
     },
     {
       title: 'Xor Shader Tutorials',
@@ -28,6 +28,10 @@ export const resources: ResourceList = {
   ],
   'GML Video Tutorials and Channels:': [
     {
+      title: 'Official YYG tutorials page',
+      url: 'https://www.yoyogames.com/tutorials'
+    },
+    {
       title: 'Pixelated Pope',
       url: 'https://www.youtube.com/user/PixelatedPope'
     },
@@ -40,7 +44,7 @@ export const resources: ResourceList = {
       url: 'https://www.youtube.com/user/uheartbeast'
     },
     {
-      title: 'Freindly Cosmonaut',
+      title: 'Friendly Cosmonaut',
       url: 'https://www.youtube.com/channel/UCKCKHxkH8zqV9ltWZw0JFig'
     },
     {
@@ -48,7 +52,7 @@ export const resources: ResourceList = {
       url: 'https://www.youtube.com/channel/UCcYKLm0EwyWkfTA6sMn5W7g'
     },
     {
-      title: 'Official YYG Youtube',
+      title: 'Official YYG YouTube channel',
       url: 'https://www.youtube.com/user/yoyogamesltd'
     }
   ],
@@ -62,38 +66,37 @@ export const resources: ResourceList = {
       url: 'https://www.youtube.com/watch?v=iJH_uTq9iOQ'
     }
   ],
-  'Basic Art Skill Articles:': [
-    {
-      title: 'Guide to Being A Respectful Critic',
-      url: 'http://tiny.cc/critique'
-    },
-    {
-      title: 'Basic Guide to Pixelart',
-      url: 'http://pixeljoint.com/forum/forum_posts.asp?TID=11299'
-    }
-  ],
-  'Art Video Resources and Channels:': [
+  'Pixel Art Articles and Video Resources:': [
     {
       title: 'MortMort',
       url: 'https://www.youtube.com/user/atMNRArt'
     },
     {
+      title: 'Basic Guide to Pixel Art',
+      url: 'http://pixeljoint.com/forum/forum_posts.asp?TID=11299'
+    },
+    {
       title: 'Guide on Choosing the Right Canvas Size',
       url: 'https://www.youtube.com/watch?v=AXb-VBZTKDA'
+    },
+    {
+      title: 'Pixel Logic Book',
+      url: 'https://pixellogicbook.com/'
     }
   ],
-  'Pixelart Refrence Sites and Tutorials:': [
+  'Pixel Art Reference Sites and Tutorials:': [
     {
       title: 'Miniboss',
       url: 'http://blog.studiominiboss.com/pixelart'
     },
     {
-      title: 'The Spriters Recource',
+      title: 'The Spriters Resource',
       url: 'https://www.spriters-resource.com/'
     },
     {
-      title: 'Find Palletes Here',
-      url: 'https://lospec.com/palette-list'
+      title: 'Lospec Palette List',
+      url: 'https://lospec.com/palette-list',
+      label: 'Find colour palettes here:'
     },
     {
       title: 'Guide to Subpixel Animation',

--- a/src/commands/starter/starter.command.ts
+++ b/src/commands/starter/starter.command.ts
@@ -26,7 +26,7 @@ export class StarterCommand implements CommandClass {
 
       // Load in those saucy recources
       const kitEmbed = new MessageEmbed ({
-        title: '__**r/GM Resource Pack**__',
+        title: '__**GameMaker Resource Pack**__',
         description: '**The following is a set of useful sources for learning GML and other GameMaker development skills.**',
         thumbnail: {  url: 'https://www.yoyogames.com/images/gms2_logo_512.png'  },
         fields: this.constructEmbedFields(resources),


### PR DESCRIPTION
I've made various changes to the `!starter` command by removing or updating old links, fixing various typos, replacing "r/GM" in the title, etc.

I also added two resources that I think are worth adding:
- The official YYG tutorials page, this has a massive collection of beginner tutorials that I link every time someone asks for tutorials, so it will be handy to have it in `!starter`.
- The Pixel Logic book, which teaches various pixel art techniques. It isn't free, but it's reputable and has taught me a lot of things personally.

Here's what the changes look like:

![old-vs-new](https://user-images.githubusercontent.com/37968413/137100882-6d93dbb7-b31a-4442-a55b-cbcd14c7f7d3.png)
