### PR TITLE
Added backtick command note for language syntax highlighting

### DIFF
--- a/src/commands/global/backtick.ts
+++ b/src/commands/global/backtick.ts
@@ -12,9 +12,10 @@ export const cmd: BotCommand = {
       embeds: [
         new EmbedBuilder()
         .setTitle('You can format your code by encapsulating it within three backticks before and after')
-        .setDescription('\n\\`\\`\\`\nshow_debug_message("I\'m formatted!");\n\\`\\`\\`\n\n' +
+        .setDescription('\n\\`\\`\\`gml\nshow_debug_message("I\'m formatted!");\n\\`\\`\\`\n\n' +
+        'Include syntax highlighting by putting "gml" after the first three backticks\n' +
         'The above example displays:\n' +
-        '```\nshow_debug_message("I\'m formatted!");\n```\n' +
+        '```gml\nshow_debug_message("I\'m formatted!");\n```\n' +
         `The backtick key can be found above the TAB key on most keyboards.`)
         .setImage('https://cdn.discordapp.com/attachments/441976514289074201/456562731903090697/backtick.png')
         .setColor(config.defaultEmbedColor)


### PR DESCRIPTION
Adds a note to the backslash command about formatting the code block to use syntax highlighting. Showing the user how to include syntax highlighted will make it easier on those who are helping to read the code.